### PR TITLE
Fix typos (iso 8601, semver)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ During analysis ERMI will reference external sources such as country risk scores
 The following conventions are true for all ERMI Batch File Format files:
 
 1. The first row **MUST** be a heading row listing columns. Columns **MAY** appear in any order.
-2. Date columns **MUST** be in [ISO-8061 format.](https://www.iso.org/iso-8601-date-and-time-format.html) including a time, timezone and separated using the dash (-) character. 
+2. Date columns **MUST** be in [ISO-8601 format.](https://www.iso.org/iso-8601-date-and-time-format.html) including a time, timezone and separated using the dash (-) character. 
 3. Countries **SHOULD** be in [ISO-3166 ALPHA 2](https://www.iso.org/iso-3166-country-codes.html) format.
 4. Currencies **MUST** be referred too using the [ISO 4217](https://www.iso.org/iso-4217-currency-codes.html) standard names
 5. Column names are case sensitive and must appears exactly as defined below.
@@ -53,7 +53,7 @@ The following Columns **MUST** be present in all files.
 | Name   | Brief Description | Validation |
 | :----- | :---------------- | :--------- |
 | transactionID | A uniqueID for this transaction | ```0-9[a-Z]``` |
-| date | The date and time at which the transaction occurred | [ISO-8061](https://www.iso.org/iso-8601-date-and-time-format.html) |
+| date | The date and time at which the transaction occurred | [ISO-8601](https://www.iso.org/iso-8601-date-and-time-format.html) |
 | currency | The currency used for the transaction represented as a currency code | [ISO 4217](https://www.iso.org/iso-4217-currency-codes.html) | 
 | value | The quantity of currency sent as a float or integer | ```[0-9]+(\.[0-9][0-9]?)? ```|
 | beneficiaryID | A unique ID representing the beneficiary person or legal entity (for example, ERMI Software Ltd) | ```0-9[a-Z]``` |
@@ -79,7 +79,7 @@ The following columns **MAY** be present for the _payer_.
 | payerCompanyName | The payers company name (Blank if individual)| ```0-9[a-Z]``` |
 | payerCompaniesHouseNumber | The payers company house number if UK (Blank if individual)| ```0-9[a-Z]``` |
 | payerPostcode | The payers postcode| ```0-9[a-Z]``` |
-| payerCreatedAt | The date and time at which the payer was created| [ISO-8061](https://www.iso.org/iso-8601-date-and-time-format.html) |
+| payerCreatedAt | The date and time at which the payer was created| [ISO-8601](https://www.iso.org/iso-8601-date-and-time-format.html) |
 | payerAccountID | Human readable unique account ID | ```0-9[a-Z]``` |
 | payerAccountNumber | Payer account number within.  | ```0-9[a-Z]``` |
 | payerAccountRoutingCode | Payer account routine code, clearing code, or sort code  | ```0-9[a-Z]``` |
@@ -101,7 +101,7 @@ The following columns **MAY** be present for the _beneficiary_.
 | beneficiaryLastName | The beneficiaries last name. (Blank if corporate) | ```0-9[a-Z]``` |
 | beneficiaryCompanyName | The beneficiaries company name (Blank if individual)| ```0-9[a-Z]``` |
 | beneficiaryPostcode | The beneficiaries postcode| ```0-9[a-Z]``` |
-| beneficiaryCreatedAt | The date and time at which the beneficiary was created| [ISO-8061](https://www.iso.org/iso-8601-date-and-time-format.html) |
+| beneficiaryCreatedAt | The date and time at which the beneficiary was created| [ISO-8601](https://www.iso.org/iso-8601-date-and-time-format.html) |
 | beneficiaryPostcode | The beneficiaries postcode| ```0-9[a-Z]``` |
 | beneficiaryAccountID | Human readable unique account ID | ```0-9[a-Z]``` |
 | beneficiaryAccountNumber | Beneficiaries account number.  | ```0-9[a-Z]``` |
@@ -118,7 +118,7 @@ The following columns **MAY** be present for the _sender_.
 | senderCompanyName | The sender company name | ```0-9[a-Z]``` |
 | senderCountry | The location where the sender resides | [ISO-3166 ALPHA 2](https://www.iso.org/iso-3166-country-codes.html) |
 | senderRisk | The risk profile of the sender | 'very low', 'low', 'medium', 'medium high', 'high' |
-| senderCreatedAt | The date and time at which the sender was created| [ISO-8061](https://www.iso.org/iso-8601-date-and-time-format.html) |
+| senderCreatedAt | The date and time at which the sender was created| [ISO-8601](https://www.iso.org/iso-8601-date-and-time-format.html) |
 | senderPostcode | The senders postcode| ```0-9[a-Z]``` |
 | senderAccountID | Human readable unique account ID | ```0-9[a-Z]``` |
 | senderAccountNumber | Senders account number.  | ```0-9[a-Z]``` |
@@ -138,7 +138,7 @@ The following columns **MAY** be present for the _receiver_.
 | receiverCompanyName | The receivers company name (Blank if individual)| ```0-9[a-Z]``` |
 | receiverCountry | The location where the receiver resides | [ISO-3166 ALPHA 2](https://www.iso.org/iso-3166-country-codes.html) |
 | receiverRisk | The risk profile of the receiver | 'very low', 'low', 'medium', 'medium high', 'high' |
-| receiverCreatedAt | The date and time at which the receiver was created| [ISO-8061](https://www.iso.org/iso-8601-date-and-time-format.html) |
+| receiverCreatedAt | The date and time at which the receiver was created| [ISO-8601](https://www.iso.org/iso-8601-date-and-time-format.html) |
 | receiverPostcode | The receivers postcode| ```0-9[a-Z]``` |
 | receiverAccountID | Human readable unique account ID | ```0-9[a-Z]``` |
 | receiverAccountNumber | Receivers account number.  | ```0-9[a-Z]``` |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ ERMI is a lightweight transaction monitoring tool designed to simplify complianc
 
 ## Overview
 
-For batch operation ERMI consumes a CSV [RFC 4180](https://tools.ietf.org/html/rfc4180) formatted text file. This file is made up of a number of columns representing the ERMI Data Model. This specification is versioned using the [semvar versioning system](https://semver.org). The version can be found at the top of this document, the latest version can always be found at https://github.com/ermi-ltd/ermi-file-format/
+For batch operation ERMI consumes a CSV [RFC 4180](https://tools.ietf.org/html/rfc4180) formatted text file. This file is made up of a number of columns representing the ERMI Data Model. This specification is versioned using the [semver versioning system](https://semver.org). The version can be found at the top of this document, the latest version can always be found at https://github.com/ermi-ltd/ermi-file-format/
 
 ## ERMI Data Model.
 


### PR DESCRIPTION
Fixes typos. 

* Should be ISO 8601 for dates (not ISO 8061 because that is for Alpine ski-bindings)
* Semver (not semvar)

Includes changes from pull request https://github.com/ERMI-Software/ermi-file-format/pull/9 and supersedes it.